### PR TITLE
Fix makefile for creating egress-router image

### DIFF
--- a/images/egress-router/Dockerfile
+++ b/images/egress-router/Dockerfile
@@ -1,16 +1,13 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as rhel8
 FROM golang:1.13 as builder
 
 WORKDIR /go/src/github.com/openshift/egress-router-cni
-COPY go.mod .
-COPY go.sum .
-
-RUN go mod download
 
 COPY . .
 RUN ./hack/build-go.sh
 
 FROM openshift/origin-base
-COPY --from=builder /go/src/github.com/openshift/egress-router-cni/bin/egress-router /egress-router
+COPY --from=builder /go/src/github.com/openshift/egress-router-cni/bin/egress-router /usr/src/egress-router-cni/bin/egress-router
 
 LABEL io.k8s.display-name="Egress Router CNI" \
       io.k8s.description="CNI Plugin for Egress Router" \


### PR DESCRIPTION
This commit fixes the Makefile and adds the hack/build-go.sh script to
create the build image. It also changes the Dockerfile to take go.mod
into consideration.